### PR TITLE
Implement dark theme toggle with landing/login exclusions

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,10 +1,13 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { ToastContainerComponent } from './features/notifications/ui/toast-container/toast-container.component';
+import { ThemeService } from './shared/data/theme.service';
 
 @Component({
   selector: 'app-root',
   imports: [RouterOutlet, ToastContainerComponent],
   templateUrl: './app.html',
 })
-export class App {}
+export class App {
+  constructor(private readonly _themeService: ThemeService) {}
+}

--- a/src/app/shared/data/theme.service.ts
+++ b/src/app/shared/data/theme.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, Renderer2, RendererFactory2, inject, signal } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs';
+
+type Theme = 'light' | 'dark';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private static readonly STORAGE_KEY = 'orbita-theme';
+  private readonly blockedRoutes = new Set(['', 'login']);
+
+  private readonly router = inject(Router);
+  private readonly renderer: Renderer2;
+
+  private readonly preferredTheme = signal<Theme>(this.readStoredTheme());
+  readonly theme = signal<Theme>('light');
+
+  constructor(rendererFactory: RendererFactory2) {
+    this.renderer = rendererFactory.createRenderer(null, null);
+    this.applyThemeForUrl(this.router.url);
+
+    this.router.events
+      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+      .subscribe(event => this.applyThemeForUrl(event.urlAfterRedirects));
+  }
+
+  get isDarkTheme(): boolean {
+    return this.theme() === 'dark';
+  }
+
+  toggleTheme(): void {
+    const nextTheme: Theme = this.preferredTheme() === 'dark' ? 'light' : 'dark';
+    this.preferredTheme.set(nextTheme);
+    localStorage.setItem(ThemeService.STORAGE_KEY, nextTheme);
+    this.applyThemeForUrl(this.router.url);
+  }
+
+  private applyThemeForUrl(url: string): void {
+    const activeTheme = this.isBlockedRoute(url) ? 'light' : this.preferredTheme();
+    this.theme.set(activeTheme);
+    this.renderer.setAttribute(document.documentElement, 'data-theme', activeTheme);
+  }
+
+  private isBlockedRoute(url: string): boolean {
+    const cleanUrl = url.split('?')[0].split('#')[0];
+    const segment = cleanUrl.replace(/^\//, '').split('/')[0] ?? '';
+    return this.blockedRoutes.has(segment);
+  }
+
+  private readStoredTheme(): Theme {
+    return localStorage.getItem(ThemeService.STORAGE_KEY) === 'dark' ? 'dark' : 'light';
+  }
+}

--- a/src/app/shared/ui/app-shell/app-shell.component.scss
+++ b/src/app/shared/ui/app-shell/app-shell.component.scss
@@ -2,8 +2,8 @@
   height: 100vh;
   display: flex;
   overflow: hidden;
-  background: #f5f7f8;
-  color: #111418;
+  background: var(--surface-app);
+  color: var(--text-main);
 }
 
 .main {

--- a/src/app/shared/ui/slim-sidebar/slim-sidebar.component.scss
+++ b/src/app/shared/ui/slim-sidebar/slim-sidebar.component.scss
@@ -1,8 +1,8 @@
 .sidebar {
   width: 100px;
   height: 100%;
-  background: #ffffff;
-  border-right: 1px solid #e5e7eb;
+  background: var(--surface-panel);
+  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -44,7 +44,7 @@
 .nav__item {
   position: relative;
   width: 100%;
-  color: #60758a;
+  color: var(--icon-muted);
   text-decoration: none;
   display: flex;
   flex-direction: column;
@@ -98,7 +98,7 @@
   border: 0;
   background: transparent;
   cursor: pointer;
-  color: #60758a;
+  color: var(--icon-muted);
   padding: 8px;
   border-radius: 10px;
 

--- a/src/app/shared/ui/topbar/topbar.component.html
+++ b/src/app/shared/ui/topbar/topbar.component.html
@@ -11,8 +11,13 @@
   </div>
 
   <div class="right">
-    <button class="iconbtn" type="button" (click)="toggleTheme()" aria-label="Тема">
-      <span class="material-symbols-outlined">dark_mode</span>
+    <button
+      class="iconbtn"
+      type="button"
+      (click)="toggleTheme()"
+      [attr.aria-label]="themeService.isDarkTheme ? 'Светлая тема' : 'Темная тема'"
+    >
+      <span class="material-symbols-outlined">{{ themeService.isDarkTheme ? 'light_mode' : 'dark_mode' }}</span>
     </button>
 
     <div class="notify-wrapper">

--- a/src/app/shared/ui/topbar/topbar.component.scss
+++ b/src/app/shared/ui/topbar/topbar.component.scss
@@ -1,7 +1,7 @@
 .topbar {
   height: 64px;
-  background: #ffffff;
-  border-bottom: 1px solid #e5e7eb;
+  background: var(--surface-panel);
+  border-bottom: 1px solid var(--border-color);
   padding: 0 32px;
 
   display: flex;
@@ -31,7 +31,7 @@
   left: 12px;
   top: 50%;
   transform: translateY(-50%);
-  color: #60758a;
+  color: var(--icon-muted);
   font-size: 20px;
 }
 
@@ -41,10 +41,12 @@
   outline: none;
   border-radius: 10px;
   padding: 8px 12px 8px 40px;
-  background: #f5f7f8;
+  background: var(--surface-muted);
   font-size: 13px;
 
-  &::placeholder { color: #60758a; }
+  color: var(--text-main);
+
+  &::placeholder { color: var(--icon-muted); }
 }
 
 .right {
@@ -56,14 +58,14 @@
 .iconbtn {
   position: relative;
   border: 0;
-  background: #f5f7f8;
-  color: #60758a;
+  background: var(--surface-muted);
+  color: var(--icon-muted);
   cursor: pointer;
   padding: 8px;
   border-radius: 10px;
   transition: background .2s ease;
 
-  &:hover { background: #e5e7eb; }
+  &:hover { background: var(--border-color); }
 }
 
 .notify-wrapper {
@@ -85,14 +87,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid #ffffff;
+  border: 2px solid var(--surface-panel);
   line-height: 1;
 }
 
 .divider {
   width: 1px;
   height: 24px;
-  background: #e5e7eb;
+  background: var(--border-color);
 }
 
 .profile {
@@ -106,7 +108,7 @@
   border-radius: 10px;
   transition: background 0.2s ease;
 
-  &:hover { background: #f5f7f8; }
+  &:hover { background: var(--surface-muted); }
 }
 
 .profile__avatar {
@@ -129,6 +131,6 @@
 .profile__name {
   font-size: 13px;
   font-weight: 600;
-  color: #111418;
+  color: var(--text-main);
   white-space: nowrap;
 }

--- a/src/app/shared/ui/topbar/topbar.component.ts
+++ b/src/app/shared/ui/topbar/topbar.component.ts
@@ -3,6 +3,7 @@ import { RouterLink } from '@angular/router';
 import { UserService } from '../../../features/user/data/user.service';
 import { NotificationService } from '../../../features/notifications/data/notification.service';
 import { NotificationDropdownComponent } from '../../../features/notifications/ui/notification-dropdown/notification-dropdown.component';
+import { ThemeService } from '../../data/theme.service';
 
 @Component({
   selector: 'app-topbar',
@@ -17,12 +18,13 @@ export class TopbarComponent {
 
   protected readonly userService = inject(UserService);
   protected readonly notificationService = inject(NotificationService);
+  protected readonly themeService = inject(ThemeService);
   private readonly elRef = inject(ElementRef);
 
   readonly showNotifications = signal(false);
 
   toggleTheme(): void {
-    console.log('toggle theme');
+    this.themeService.toggleTheme();
   }
 
   toggleNotifications(): void {

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -3,6 +3,13 @@
   --bg-light: #fcfcfc;
   --bg-dark: #101922;
 
+  --surface-app: #f5f7f8;
+  --surface-panel: #ffffff;
+  --surface-muted: #f5f7f8;
+  --border-color: #e5e7eb;
+  --icon-muted: #60758a;
+  --text-main: #111418;
+
   --text-900: #111827; // gray-900
   --text-600: #4b5563; // gray-600
   --text-500: #6b7280; // gray-500
@@ -17,6 +24,19 @@
   --shadow-hero-hover: 0 25px 60px rgba(37, 140, 244, 0.40);
 }
 
+:root[data-theme='dark'] {
+  --surface-app: #101922;
+  --surface-panel: #17212c;
+  --surface-muted: #202d3c;
+  --border-color: #2d3a49;
+  --icon-muted: #b4c3d6;
+  --text-main: #edf2f7;
+  --text-900: #edf2f7;
+  --text-600: #c5d1df;
+  --text-500: #9badc2;
+  --text-400: #8296ad;
+}
+
 html, body {
   height: 100%;
   margin: 0;
@@ -24,6 +44,6 @@ html, body {
 
 body {
   font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-  background: var(--bg-light);
+  background: var(--surface-app);
   color: var(--text-900);
 }


### PR DESCRIPTION
### Motivation
- The TopBar theme switch was a no-op and the app needed a persistent, route-aware dark/light theme mechanism. 
- The dark theme must never be applied on the public landing (`/`) and auth (`/login`) pages while preserving user preference for the authenticated app.

### Description
- Added `ThemeService` (`src/app/shared/data/theme.service.ts`) that stores the preferred theme in `localStorage`, applies `data-theme` on `<html>`, listens to route changes, and enforces route-based exclusions for landing and login. 
- Wired theme initialization into the app root by injecting `ThemeService` in `src/app/app.ts` so theme is applied on startup. 
- Hooked the TopBar button to toggle theme and made the icon and `aria-label` dynamic (`src/app/shared/ui/topbar/topbar.component.ts` and `.html`). 
- Introduced theme design tokens and adapted shared styles to use them (variables and `:root[data-theme='dark']`) and updated shell/sidebar/topbar SCSS to consume tokens for consistent dark-mode visuals (`src/styles/_tokens.scss`, `src/app/shared/ui/app-shell/app-shell.component.scss`, `src/app/shared/ui/slim-sidebar/slim-sidebar.component.scss`, `src/app/shared/ui/topbar/topbar.component.scss`).

### Testing
- Ran TypeScript check with `npx tsc -p tsconfig.app.json --noEmit`, which completed successfully. 
- Built and served the app with the dev server (`npm run start`), the dev server built and served the app for visual checks successfully. 
- Attempted `npm run build` but it failed in this environment due to external Google Fonts inlining returning `403` (unrelated to the theme changes). 
- Captured a landing page screenshot from the running server for visual verification (`artifacts/landing-light.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47bc0bb088322a1fb0e72768a5b5d)