### PR TITLE
fix(finance): align stat cards and transactions card to equal height

### DIFF
--- a/src/app/pages/finance/finance-page.component.scss
+++ b/src/app/pages/finance/finance-page.component.scss
@@ -67,13 +67,22 @@ $finance-accent-border: rgba(250, 204, 21, 0.30);
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 32px;
-  align-items: start;
+  align-items: stretch;
 }
 
 .top-grid__stats {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.top-grid__transactions {
+  display: flex;
+  flex-direction: column;
+
+  .transactions-card {
+    flex: 1;
+  }
 }
 
 // ─── Section divider ───


### PR DESCRIPTION
Change top-grid from align-items: start to stretch so both columns match height, and make transactions-card fill available space.

https://claude.ai/code/session_01MronW4BMKWEbTdhxLSoyzL