### PR TITLE
Fix finance chart not displaying on load and wrong period on switch

### DIFF
--- a/src/app/pages/finance/finance-page.component.ts
+++ b/src/app/pages/finance/finance-page.component.ts
@@ -8,6 +8,7 @@ import {
   signal,
   computed,
   inject,
+  effect,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AppShellComponent } from '../../shared/ui/app-shell/app-shell.component';
@@ -40,8 +41,19 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
 
   @ViewChild('spendingChart') chartCanvas!: ElementRef<HTMLCanvasElement>;
   private chart: Chart | null = null;
+  private viewReady = false;
 
   readonly activeChartTab = signal<'weekly' | 'monthly'>('weekly');
+
+  private chartEffect = effect(() => {
+    // Track signals so the effect re-runs when data or limits change
+    this.financeService.chartData();
+    this.financeService.limits();
+    if (this.viewReady) {
+      this.chart?.destroy();
+      this.createChart();
+    }
+  });
 
   // ─── State (delegated to service) ───
 
@@ -312,6 +324,8 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
+    this.viewReady = true;
+    this.chart?.destroy();
     this.createChart();
   }
 
@@ -330,8 +344,6 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
   setChartTab(tab: 'weekly' | 'monthly'): void {
     this.activeChartTab.set(tab);
     this.financeService.loadChartData(tab);
-    this.chart?.destroy();
-    this.createChart();
   }
 
   // ─── Formatters ───
@@ -458,8 +470,6 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
       weeklyLimit: !isNaN(wl) && wl > 0 ? Math.round(wl * 100) : 0,
     });
     this.showLimitDialog.set(false);
-    this.chart?.destroy();
-    this.createChart();
   }
 
   // ─── History dialog ───


### PR DESCRIPTION
## Summary

- Fix chart not rendering on initial page load (async data race condition)
- Fix week/month tabs showing swapped data when switching periods
- Replace manual `createChart()` calls with an Angular `effect()` that reactively watches `chartData` and `limits` signals

## Root cause

`createChart()` was called synchronously in `ngAfterViewInit` and `setChartTab`, but chart data is loaded asynchronously via HTTP. This meant:
1. On page load — chart data hadn't arrived yet → empty chart
2. On tab switch — old period's data was still in the signal → wrong chart displayed

## Test plan

- [ ] Open finance page — chart should render correctly for the default (weekly) tab
- [ ] Switch to monthly — chart should show monthly data
- [ ] Switch back to weekly — chart should show weekly data
- [ ] Update spending limits — chart limit line should update automatically

https://claude.ai/code/session_01Azvx45ndf6vvjjWJzMhnpg