### PR TITLE
Fix finance chart not displaying on load and showing wrong period on …

### DIFF
--- a/src/app/pages/finance/finance-page.component.ts
+++ b/src/app/pages/finance/finance-page.component.ts
@@ -8,6 +8,7 @@ import {
   signal,
   computed,
   inject,
+  effect,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AppShellComponent } from '../../shared/ui/app-shell/app-shell.component';
@@ -40,8 +41,19 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
 
   @ViewChild('spendingChart') chartCanvas!: ElementRef<HTMLCanvasElement>;
   private chart: Chart | null = null;
+  private viewReady = false;
 
   readonly activeChartTab = signal<'weekly' | 'monthly'>('weekly');
+
+  private chartEffect = effect(() => {
+    // Track signals so the effect re-runs when data or limits change
+    this.financeService.chartData();
+    this.financeService.limits();
+    if (this.viewReady) {
+      this.chart?.destroy();
+      this.createChart();
+    }
+  });
 
   // ─── State (delegated to service) ───
 
@@ -312,6 +324,8 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
+    this.viewReady = true;
+    this.chart?.destroy();
     this.createChart();
   }
 
@@ -330,8 +344,6 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
   setChartTab(tab: 'weekly' | 'monthly'): void {
     this.activeChartTab.set(tab);
     this.financeService.loadChartData(tab);
-    this.chart?.destroy();
-    this.createChart();
   }
 
   // ─── Formatters ───
@@ -458,8 +470,6 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
       weeklyLimit: !isNaN(wl) && wl > 0 ? Math.round(wl * 100) : 0,
     });
     this.showLimitDialog.set(false);
-    this.chart?.destroy();
-    this.createChart();
   }
 
   // ─── History dialog ───


### PR DESCRIPTION
…tab switch

The chart was created synchronously in ngAfterViewInit and setChartTab, but chartData is loaded asynchronously via HTTP. This caused:
- No chart on initial page load (data not yet arrived)
- Swapped week/month data on tab switch (old data still in signal)

Replace manual createChart() calls with an Angular effect that watches the chartData and limits signals, recreating the chart when data arrives.

https://claude.ai/code/session_01Azvx45ndf6vvjjWJzMhnpg