### PR TITLE
feat: add category editing on expense analytics page

### DIFF
--- a/src/app/features/finance/data/finance.service.ts
+++ b/src/app/features/finance/data/finance.service.ts
@@ -7,6 +7,7 @@ import {
   Category,
   ChartDataPoint,
   CreateCategoryDto,
+  UpdateCategoryDto,
   CreateSavingsGoalDto,
   CreateShoppingListDto,
   CreateShoppingListItemDto,
@@ -31,6 +32,7 @@ import {
  *
  * GET    /api/Finance/categories                     → Category[]                  Load all categories
  * POST   /api/Finance/categories                     → Category                    Create a category. Body: CreateCategoryDto
+ * PUT    /api/Finance/categories/:id                 → Category                    Update a category. Body: UpdateCategoryDto
  *
  * GET    /api/Finance/transactions                   → Transaction[]               Load all transactions
  * POST   /api/Finance/transactions                   → Transaction                 Create a transaction. Body: CreateTransactionDto
@@ -121,6 +123,27 @@ export class FinanceService {
         },
         error: () => {
           this.categories.update(list => list.filter(c => c.id !== tempId));
+        },
+      });
+  }
+
+  updateCategory(id: string, dto: UpdateCategoryDto): void {
+    const backup = this.categories();
+
+    // Optimistic update
+    this.categories.update(list =>
+      list.map(c => c.id === id ? { ...c, ...dto } : c),
+    );
+
+    this.http.put<Category>(`${this.apiUrl}/api/Finance/categories/${id}`, dto)
+      .subscribe({
+        next: updated => {
+          this.categories.update(list =>
+            list.map(c => c.id === id ? updated : c),
+          );
+        },
+        error: () => {
+          this.categories.set(backup);
         },
       });
   }

--- a/src/app/features/finance/models/finance.models.ts
+++ b/src/app/features/finance/models/finance.models.ts
@@ -63,6 +63,15 @@ export interface CreateCategoryDto {
   monthlyLimit?: number;
 }
 
+export interface UpdateCategoryDto {
+  name?: string;
+  icon?: string;
+  bg?: string;
+  color?: string;
+  weeklyLimit?: number;
+  monthlyLimit?: number;
+}
+
 export interface CreateTransactionDto {
   categoryId: string;
   title: string;

--- a/src/app/pages/finance/finance-page.component.html
+++ b/src/app/pages/finance/finance-page.component.html
@@ -188,6 +188,14 @@
           <div class="category-chips">
             @for (cs of categorySpending(); track cs.id) {
               <div class="category-chip" [class.category-chip--over]="cs.isOverLimit">
+                <button
+                  class="category-chip__edit-btn"
+                  type="button"
+                  title="Редактировать категорию"
+                  (click)="openEditCategoryDialog(cs)"
+                >
+                  <span class="material-symbols-outlined">edit</span>
+                </button>
                 <div class="category-chip__icon" [style.background]="cs.bg" [style.color]="cs.color">
                   <span class="material-symbols-outlined">{{ cs.icon }}</span>
                 </div>
@@ -377,8 +385,8 @@
       <div class="dialog__icon-circle dialog__icon-circle--blue">
         <span class="material-symbols-outlined">category</span>
       </div>
-      <h3 class="dialog__title">Новая категория</h3>
-      <p class="dialog__desc">Создайте категорию для отслеживания расходов</p>
+      <h3 class="dialog__title">{{ editCategoryId ? 'Редактировать категорию' : 'Новая категория' }}</h3>
+      <p class="dialog__desc">{{ editCategoryId ? 'Измените параметры категории' : 'Создайте категорию для отслеживания расходов' }}</p>
 
       <div class="dialog__fields">
         <div class="field">
@@ -457,7 +465,7 @@
           Отмена
         </button>
         <button class="dialog__btn dialog__btn--primary" type="button" (click)="saveCategory()">
-          Создать
+          {{ editCategoryId ? 'Сохранить' : 'Создать' }}
         </button>
       </div>
     </div>

--- a/src/app/pages/finance/finance-page.component.scss
+++ b/src/app/pages/finance/finance-page.component.scss
@@ -375,6 +375,39 @@ $finance-accent-border: rgba(250, 204, 21, 0.30);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  position: relative;
+
+  &:hover .category-chip__edit-btn {
+    opacity: 1;
+  }
+}
+
+.category-chip__edit-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: var(--surface-hover);
+  color: var(--text-400);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease;
+  padding: 0;
+
+  .material-symbols-outlined {
+    font-size: 14px;
+  }
+
+  &:hover {
+    background: var(--border-color);
+    color: var(--text-600);
+  }
 }
 
 .category-chip__icon {

--- a/src/app/pages/finance/finance-page.component.ts
+++ b/src/app/pages/finance/finance-page.component.ts
@@ -298,6 +298,7 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
   categorySelectedColorIdx = 0;
   categoryWeeklyLimit = '';
   categoryMonthlyLimit = '';
+  editCategoryId: string | null = null;
 
   // Goal form
   goalType: 'goal' | 'shoppingList' = 'goal';
@@ -431,11 +432,23 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
   // ─── Category dialog ───
 
   openCategoryDialog(): void {
+    this.editCategoryId = null;
     this.categoryName = '';
     this.categorySelectedIcon = 'restaurant';
     this.categorySelectedColorIdx = 0;
     this.categoryWeeklyLimit = '';
     this.categoryMonthlyLimit = '';
+    this.showCategoryDialog.set(true);
+  }
+
+  openEditCategoryDialog(cat: Category): void {
+    this.editCategoryId = cat.id;
+    this.categoryName = cat.name;
+    this.categorySelectedIcon = cat.icon;
+    this.categorySelectedColorIdx = this.colorOptions.findIndex(c => c.bg === cat.bg && c.color === cat.color);
+    if (this.categorySelectedColorIdx < 0) this.categorySelectedColorIdx = 0;
+    this.categoryWeeklyLimit = cat.weeklyLimit ? (cat.weeklyLimit / 100).toString() : '';
+    this.categoryMonthlyLimit = cat.monthlyLimit ? (cat.monthlyLimit / 100).toString() : '';
     this.showCategoryDialog.set(true);
   }
 
@@ -445,14 +458,19 @@ export class FinancePageComponent implements OnInit, AfterViewInit, OnDestroy {
     const c = this.colorOptions[this.categorySelectedColorIdx];
     const wl = parseFloat(this.categoryWeeklyLimit.replace(',', '.'));
     const ml = parseFloat(this.categoryMonthlyLimit.replace(',', '.'));
-    this.financeService.createCategory({
+    const data = {
       name,
       icon: this.categorySelectedIcon,
       bg: c.bg,
       color: c.color,
       weeklyLimit: !isNaN(wl) && wl > 0 ? Math.round(wl * 100) : undefined,
       monthlyLimit: !isNaN(ml) && ml > 0 ? Math.round(ml * 100) : undefined,
-    });
+    };
+    if (this.editCategoryId) {
+      this.financeService.updateCategory(this.editCategoryId, data);
+    } else {
+      this.financeService.createCategory(data);
+    }
     this.showCategoryDialog.set(false);
   }
 


### PR DESCRIPTION
Show an edit button on hover over category chips in "Расходы по категориям". Clicking it opens the category dialog pre-filled with current values, allowing users to update name, icon, color, and limits.